### PR TITLE
Corrected chat.PostMessage API call. Added gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+### WebStorm ###
+*.iml
+.idea/

--- a/src/deg.slackapi.services.js
+++ b/src/deg.slackapi.services.js
@@ -291,7 +291,7 @@
                 channel: channeId,
                 text: message
             };
-            executeApiCall("channels.info", params, callback);
+            executeApiCall("chat.postMessage", params, callback);
         }
         function deleteMessage(channeId, timestamp, callback, token) {
             var params = {


### PR DESCRIPTION
I'm pretty sure that this was a simple mistake where you used:

```
executeApiCall("channels.info", params, callback);
```

instead of:

```
executeApiCall("chat.postMessage", params, callback);
```

for the postMessage function.

I also added a .gitignore file to ignore files and folder from the WebStorm IDE.
