### PR TITLE
Adding redirect_uri to oauth.access call

### DIFF
--- a/build/ng-deg.slackapi.js
+++ b/build/ng-deg.slackapi.js
@@ -184,12 +184,17 @@
             slackConfig.DefaultToken = token;
             authTest(callback);
         }
-        function getAccessToken(client, secret, code, callback) {
+        function getAccessToken(client, secret, code, redirect_uri, callback) {
             var params = {
                 client_id: client,
                 client_secret: secret,
                 code: code
             };
+
+            if (angular.isDefined(redirect_uri)) {
+                params.redirect_uri = redirect_uri;
+            }
+
             executeApiCall("oauth.access", params, callback);
         }
         function authTest(callback, token) {

--- a/src/deg.slackapi.services.js
+++ b/src/deg.slackapi.services.js
@@ -165,12 +165,17 @@
             slackConfig.DefaultToken = token;
             authTest(callback);
         }
-        function getAccessToken(client, secret, code, callback) {
+        function getAccessToken(client, secret, code, redirect_uri, callback) {
             var params = {
                 client_id: client,
                 client_secret: secret,
                 code: code
             };
+
+            if (angular.isDefined(redirect_uri)) {
+                params.redirect_uri = redirect_uri;
+            }
+
             executeApiCall("oauth.access", params, callback);
         }
         function authTest(callback, token) {


### PR DESCRIPTION
If you call oauth.access without the same redirect_uri used oauth.authorize request you get an error. See https://api.slack.com/methods/oauth.access.